### PR TITLE
feat: add getTxChainLocks to RPC list and array to types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,6 +241,7 @@ RpcClient.callspec = {
   getSpentInfo: 'obj',
   getSuperBlockBudget: 'int',
   getTransaction: '',
+  getTxChainLocks: 'array',
   getTxOut: 'str int bool',
   getTxOutProof: 'str str',
   getTxOutSetInfo: '',
@@ -380,6 +381,12 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
       return (arg === true || arg == '1' || arg == 'true' || arg.toString().toLowerCase() == 'true');
     },
     obj(arg) {
+      if (typeof arg === 'string') {
+        return JSON.parse(arg);
+      }
+      return arg;
+    },
+    array(arg) {
       if (typeof arg === 'string') {
         return JSON.parse(arg);
       }


### PR DESCRIPTION
It's important to note that this takes an anonymous array as the parameter, not an object with a named key like other RPC calls in the library.

```js
- rpc.getTxChainLocks({ txids: [ "xxxx..." ] });
+ rpc.getTxChainLocks([ "xxxx..." ]);
```