### PR TITLE
ref: left type normalizers functions to the top level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,6 +241,7 @@ RpcClient.callspec = {
   getSpentInfo: 'obj',
   getSuperBlockBudget: 'int',
   getTransaction: '',
+  getTxChainLocks: 'array',
   getTxOut: 'str int bool',
   getTxOutProof: 'str str',
   getTxOutSetInfo: '',
@@ -380,6 +381,12 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
       return (arg === true || arg == '1' || arg == 'true' || arg.toString().toLowerCase() == 'true');
     },
     obj(arg) {
+      if (typeof arg === 'string') {
+        return JSON.parse(arg);
+      }
+      return arg;
+    },
+    array(arg) {
       if (typeof arg === 'string') {
         return JSON.parse(arg);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -309,6 +309,40 @@ RpcClient.callspec = {
   getUser: 'str',
 };
 
+RpcClient.typeNormalizers = {
+  array(arg) {
+    if (typeof arg === 'string') {
+      return JSON.parse(arg);
+    }
+    return arg;
+  },
+  bool(arg) {
+    return (arg === true || arg == '1' || arg == 'true' || arg.toString().toLowerCase() == 'true');
+  },
+  float(arg) {
+    return parseFloat(arg);
+  },
+  int(arg) {
+    return parseFloat(arg);
+  },
+  int_str(arg) {
+    if (typeof arg === 'number') {
+      return parseFloat(arg)
+    }
+
+    return arg.toString()
+  },
+  obj(arg) {
+    if (typeof arg === 'string') {
+      return JSON.parse(arg);
+    }
+    return arg;
+  },
+  str(arg) {
+    return arg.toString();
+  },
+};
+
 const slice = function (arr, start, end) {
   return Array.prototype.slice.call(arr, start, end);
 };
@@ -360,47 +394,13 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
     };
   }
 
-  const types = {
-    str(arg) {
-      return arg.toString();
-    },
-    int(arg) {
-      return parseFloat(arg);
-    },
-    int_str(arg) {
-      if (typeof arg === 'number') {
-        return parseFloat(arg)
-      }
-
-      return arg.toString()
-    },
-    float(arg) {
-      return parseFloat(arg);
-    },
-    bool(arg) {
-      return (arg === true || arg == '1' || arg == 'true' || arg.toString().toLowerCase() == 'true');
-    },
-    obj(arg) {
-      if (typeof arg === 'string') {
-        return JSON.parse(arg);
-      }
-      return arg;
-    },
-    array(arg) {
-      if (typeof arg === 'string') {
-        return JSON.parse(arg);
-      }
-      return arg;
-    },
-  };
-
   for (const k in apiCalls) {
     const spec = apiCalls[k].split(' ');
     for (let i = 0; i < spec.length; i++) {
-      if (types[spec[i]]) {
-        spec[i] = types[spec[i]];
+      if (RpcClient.typeNormalizers[spec[i]]) {
+        spec[i] = RpcClient.typeNormalizers[spec[i]];
       } else {
-        spec[i] = types.str;
+        spec[i] = RpcClient.typeNormalizers.str;
       }
     }
     const methodName = k.toLowerCase();


### PR DESCRIPTION
This does 2 things:
- lexicographically sorts the type normalizing functions
- raises those functions to the level of the export

Since this library is slow-moving, having these at the export level will make it easier to patch when PRs are in review.