### PR TITLE
ref+fix: simpler bool check, including 'undefined'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -235,7 +235,7 @@ RpcClient.callspec = {
   getPoolInfo: '',
   getRawMemPool: 'bool',
   getRawChangeAddress: '',
-  getRawTransaction: 'str int',
+  getRawTransaction: 'str bool',
   getReceivedByAccount: 'str int',
   getReceivedByAddress: 'str int',
   getSpentInfo: 'obj',
@@ -377,7 +377,7 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
       return parseFloat(arg);
     },
     bool(arg) {
-      return (arg === true || arg == '1' || arg == 'true' || arg.toString().toLowerCase() == 'true');
+      return (String(arg).toLowerCase() === 'true' || arg > 0);
     },
     obj(arg) {
       if (typeof arg === 'string') {


### PR DESCRIPTION
Cleaner, easier to read and understand, also handles the case of `undefined`, rather than throwing an error.

Also corrects the type of `getRawTransaction` in a backwards-compatible way.

If throwing an error for `undefined` is actually the desired behavior, this change can be made:

```diff
- return (String(arg).toLowerCase() === 'true' || arg > 0);
+ return (arg.toString().toLowerCase() === 'true' || arg > 0);
```